### PR TITLE
feat: add wiki cities clustering task

### DIFF
--- a/mteb/tasks/Clustering/WikiCitiesClustering.py
+++ b/mteb/tasks/Clustering/WikiCitiesClustering.py
@@ -1,0 +1,21 @@
+from ...abstasks.AbsTaskClustering import AbsTaskClustering
+
+
+class WikiCitiesClustering(AbsTaskClustering):
+    @property
+    def description(self):
+        return {
+            "name": "WikiCitiesClustering",
+            "hf_hub_name": "jinaai/cities_wiki_clustering",
+            "description": (
+                "Clustering of Wikipedia articles of cities by country from https://huggingface.co/datasets/wikipedia."
+                "Test set includes cities from 133 countries."
+            ),
+            "reference": "https://huggingface.co/datasets/wikipedia",
+            "type": "Clustering",
+            "category": "p2p",
+            "eval_splits": ["test"],
+            "eval_langs": ["en"],
+            "main_score": "v_measure",
+            "revision": "2af05f538fd902351ce5ec7ac84f23f71d52bae1",
+        }

--- a/mteb/tasks/Clustering/__init__.py
+++ b/mteb/tasks/Clustering/__init__.py
@@ -16,3 +16,4 @@ from .TwentyNewsgroupsClustering import *
 from .CMTEBClustering import *
 from .PolishClustering import *
 from .BigPatentClustering import *
+from .WikiCitiesClustering import *


### PR DESCRIPTION
This PR adds the WikiCitiesClustering task to the MTEB benchmark. Documents (Wikipedia articles of cities) are taken from [the English train set of the Wikipedia dataset](https://huggingface.co/datasets/wikipedia). A total of 133 countries were manually selected, and articles for the cities in these countries were collected from the Wikipedia dataset. Post-filtering selected a maximum of 200 cities per country, and removed the last 25th percentile of the countries with the lowest number of collected city articles (thereby removing all 1-document clusters).

See the distribution of labels below:
![bar-countries-filtered](https://github.com/jina-ai/mteb-long-documents/assets/55404563/35464f65-af00-4e06-9e9e-37c7f7524798)

