### PR TITLE
feat: add code search net retrieval mrr

### DIFF
--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -52,7 +52,7 @@ class AbsTaskRetrieval(AbsTask):
         corpus, queries, relevant_docs = self.corpus[split], self.queries[split], self.relevant_docs[split]
         model = model if self.is_dres_compatible(model) else DRESModel(model)
 
-        if os.getenv("RANK", None) is None:
+        if os.getenv("RANK", None) is None or os.getenv("MTEB_SINGLE_GPU", "false").lower() == "true":
             # Non-distributed
             from beir.retrieval.search.dense import DenseRetrievalExactSearch as DRES
             model = DRES(

--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -32,10 +32,42 @@ class AbsTaskRetrieval(AbsTask):
                 return False
         return True
 
-    def evaluate(
-        self,
+    def _add_main_score(self, scores):
+        if self.description["main_score"] in scores:
+            scores["main_score"] = scores[self.description["main_score"]]
+        else:
+            logger.warn(f"main score {self.description['main_score']} not found in scores {scores.keys()}")
+
+    def evaluate(self,
         model,
         split="test",
+        batch_size=128,
+        corpus_chunk_size=None,
+        score_function="cos_sim",
+        **kwargs
+    ):
+        if self.is_multilingual:
+            scores = {}
+            for lang in self.langs:
+                logger.info(f"\nTask: {self.description['name']}, split: {split}, language: {lang}. Running...")
+                scores[lang] = self._evaluate_monolingual(model, self.corpus[lang][split], self.queries[lang][split],
+                                                self.relevant_docs[lang][split],
+                                                batch_size=batch_size, corpus_chunk_size=corpus_chunk_size,
+                                                score_function=score_function, **kwargs)
+                self._add_main_score(scores[lang])
+        else:
+            scores = self._evaluate_monolingual(model, self.corpus[split], self.queries[split], self.relevant_docs[split],
+                                                batch_size=batch_size, corpus_chunk_size=corpus_chunk_size,
+                                                score_function=score_function, **kwargs)
+            self._add_main_score(scores)
+
+
+    def _evaluate_monolingual(
+        self,
+        model,
+        corpus,
+        queries,
+        relevant_docs,
         batch_size=128,
         corpus_chunk_size=None,
         score_function="cos_sim",
@@ -49,7 +81,6 @@ class AbsTaskRetrieval(AbsTask):
         if not self.data_loaded:
             self.load_data()
 
-        corpus, queries, relevant_docs = self.corpus[split], self.queries[split], self.relevant_docs[split]
         model = model if self.is_dres_compatible(model) else DRESModel(model)
 
         if os.getenv("RANK", None) is None or os.getenv("MTEB_SINGLE_GPU", "false").lower() == "true":

--- a/mteb/abstasks/AbsTaskRetrieval.py
+++ b/mteb/abstasks/AbsTaskRetrieval.py
@@ -60,7 +60,7 @@ class AbsTaskRetrieval(AbsTask):
                                                 batch_size=batch_size, corpus_chunk_size=corpus_chunk_size,
                                                 score_function=score_function, **kwargs)
             self._add_main_score(scores)
-
+        return scores
 
     def _evaluate_monolingual(
         self,

--- a/mteb/abstasks/BeIRTask.py
+++ b/mteb/abstasks/BeIRTask.py
@@ -23,7 +23,7 @@ class BeIRTask(AbsTask):
         USE_HF_DATASETS = False
 
         # TODO @nouamane: move non-distributed to `HFDataLoader`
-        if os.getenv("RANK", None) is not None:
+        if os.getenv("RANK", None) is not None and os.getenv("MTEB_SINGLE_GPU", "false").lower() == "false":
             if self.description["beir_name"].startswith("cqadupstack"):
                 raise ImportError("CQADupstack is incompatible with BEIR's HFDataLoader in a distributed setting")
             from beir.datasets.data_loader_hf import HFDataLoader 

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -255,7 +255,7 @@ class MTEB:
 
             try:
                 if isinstance(eval_splits, dict):
-                    task_eval_splits = eval_splits[task.description["name"]]
+                    task_eval_splits = eval_splits.get(task.description["name"], task.description.get("eval_splits", []))
                 elif isinstance(eval_splits, list):
                     task_eval_splits = eval_splits
                 else:

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -255,7 +255,7 @@ class MTEB:
 
             try:
                 if isinstance(eval_splits, dict):
-                    task_eval_splits = eval_splits[task.description['name']]
+                    task_eval_splits = eval_splits[task.description["name"]]
                 elif isinstance(eval_splits, list):
                     task_eval_splits = eval_splits
                 else:

--- a/mteb/evaluation/MTEB.py
+++ b/mteb/evaluation/MTEB.py
@@ -254,7 +254,13 @@ class MTEB:
                     continue
 
             try:
-                task_eval_splits = eval_splits if eval_splits is not None else task.description.get("eval_splits", [])
+                if isinstance(eval_splits, dict):
+                    task_eval_splits = eval_splits[task.description['name']]
+                elif isinstance(eval_splits, list):
+                    task_eval_splits = eval_splits
+                else:
+                    assert task_eval_splits is None
+                    task_eval_splits = task.description.get("eval_splits", [])
 
                 # load data
                 logger.info(f"Loading dataset for {task.description['name']}")

--- a/mteb/tasks/PairClassification/CoSQAPC.py
+++ b/mteb/tasks/PairClassification/CoSQAPC.py
@@ -1,0 +1,40 @@
+import os
+import json
+import urllib.request
+import tempfile
+from ...abstasks.AbsTaskPairClassification import AbsTaskPairClassification
+
+
+class CoSQAPC(AbsTaskPairClassification):
+    @property
+    def description(self):
+        return {
+            "name": "CoSQAPC",
+            "category": "s2s",
+            "type": "PairClassification",
+            "eval_splits": ["dev"],
+            "eval_langs": ["en"],
+            "main_score": "ap",
+            "revision": "70970daeab8776df92f5ea462b6173c0b46fd2d1",
+        }
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        with tempfile.TemporaryDirectory() as tmp:
+            url = "https://raw.githubusercontent.com/microsoft/CodeXGLUE/main/Text-Code/NL-code-search-WebQuery/CoSQA/cosqa-train.json"
+            test_file = os.path.join(tmp, "test_cosqa.json")
+            urllib.request.urlretrieve(url, test_file)
+            with open(test_file, "r") as f:
+                data = json.load(f)
+            os.remove(test_file)
+
+        self.dataset = {'dev': [{'sent1': [], 'sent2': [], 'labels': []},]}
+
+        for row in data:
+            self.dataset['dev'][0]['sent1'].append(row['code'])
+            self.dataset['dev'][0]['sent2'].append(row['doc'])
+            self.dataset['dev'][0]['labels'].append(row['label'])
+
+        self.data_loaded = True

--- a/mteb/tasks/PairClassification/CoSQAPC.py
+++ b/mteb/tasks/PairClassification/CoSQAPC.py
@@ -13,7 +13,7 @@ class CoSQAPC(AbsTaskPairClassification):
             "category": "s2p",
             "type": "PairClassification",
             "eval_splits": ["dev", "train"],
-            "eval_langs": ["en"],
+            "eval_langs": ["python"],
             "main_score": "ap",
             "revision": "70970daeab8776df92f5ea462b6173c0b46fd2d1",
         }

--- a/mteb/tasks/PairClassification/CoSQAPC.py
+++ b/mteb/tasks/PairClassification/CoSQAPC.py
@@ -29,7 +29,6 @@ class CoSQAPC(AbsTaskPairClassification):
         for split in eval_splits:
             with tempfile.TemporaryDirectory() as tmp:
                 url = f"https://raw.githubusercontent.com/microsoft/CodeXGLUE/main/Text-Code/NL-code-search-WebQuery/CoSQA/cosqa-{split}.json"
-                print(url)
                 test_file = os.path.join(tmp, "test_cosqa.json")
                 urllib.request.urlretrieve(url, test_file)
                 with open(test_file, "r") as f:

--- a/mteb/tasks/PairClassification/CoSQAPC.py
+++ b/mteb/tasks/PairClassification/CoSQAPC.py
@@ -10,7 +10,7 @@ class CoSQAPC(AbsTaskPairClassification):
     def description(self):
         return {
             "name": "CoSQAPC",
-            "category": "s2s",
+            "category": "s2p",
             "type": "PairClassification",
             "eval_splits": ["dev", "train"],
             "eval_langs": ["en"],

--- a/mteb/tasks/PairClassification/CoSQAPC.py
+++ b/mteb/tasks/PairClassification/CoSQAPC.py
@@ -23,7 +23,7 @@ class CoSQAPC(AbsTaskPairClassification):
             return
 
         with tempfile.TemporaryDirectory() as tmp:
-            url = "https://raw.githubusercontent.com/microsoft/CodeXGLUE/main/Text-Code/NL-code-search-WebQuery/CoSQA/cosqa-train.json"
+            url = "https://raw.githubusercontent.com/microsoft/CodeXGLUE/main/Text-Code/NL-code-search-WebQuery/CoSQA/cosqa-dev.json"
             test_file = os.path.join(tmp, "test_cosqa.json")
             urllib.request.urlretrieve(url, test_file)
             with open(test_file, "r") as f:

--- a/mteb/tasks/PairClassification/CoSQAPC.py
+++ b/mteb/tasks/PairClassification/CoSQAPC.py
@@ -29,6 +29,7 @@ class CoSQAPC(AbsTaskPairClassification):
         for split in eval_splits:
             with tempfile.TemporaryDirectory() as tmp:
                 url = f"https://raw.githubusercontent.com/microsoft/CodeXGLUE/main/Text-Code/NL-code-search-WebQuery/CoSQA/cosqa-{split}.json"
+                print(url)
                 test_file = os.path.join(tmp, "test_cosqa.json")
                 urllib.request.urlretrieve(url, test_file)
                 with open(test_file, "r") as f:

--- a/mteb/tasks/PairClassification/CoSQAPC.py
+++ b/mteb/tasks/PairClassification/CoSQAPC.py
@@ -24,9 +24,6 @@ class CoSQAPC(AbsTaskPairClassification):
 
         eval_splits = kwargs.get("eval_splits")
         eval_splits = eval_splits if eval_splits is not None else self.description["eval_splits"]
-        eval_splits = [split for split in eval_splits if split in self.description['eval_splits']]
-        if len(eval_splits) == 0:
-            eval_splits = ["dev"]
 
         self.dataset = {}
         for split in eval_splits:

--- a/mteb/tasks/PairClassification/__init__.py
+++ b/mteb/tasks/PairClassification/__init__.py
@@ -3,3 +3,4 @@ from .TwitterSemEval2015PC import *
 from .TwitterURLCorpusPC import *
 from .CMTEBPairClassification import *
 from .PolishPC import *
+from .CoSQAPC import *

--- a/mteb/tasks/Retrieval/CoSQARetrieval.py
+++ b/mteb/tasks/Retrieval/CoSQARetrieval.py
@@ -46,12 +46,15 @@ class CoSQARetrieval(AbsTaskRetrieval):
                     data = json.load(f)
                 os.remove(test_file)
 
+            known_queries = set()
             for idx, row in enumerate(data):
                 code = row['code']
                 query = row['doc']
                 label = row['label']
                 self.corpus[split][f'd{idx}'] = {'text': code}
                 if label == 1:
+                    assert query not in known_queries
+                    known_queries.add(query)
                     self.queries[split][f'q{idx}'] = query
                     self.relevant_docs[split][f'q{idx}'] = {f'd{idx}': 1}
 

--- a/mteb/tasks/Retrieval/CoSQARetrieval.py
+++ b/mteb/tasks/Retrieval/CoSQARetrieval.py
@@ -43,8 +43,12 @@ class CoSQARetrieval(AbsTaskRetrieval):
         for idx, row in enumerate(data):
             code = row['code']
             query = row['doc']
+            label = row['label']
             self.queries[self._EVAL_SPLIT][f'q{idx}'] = query
             self.corpus[self._EVAL_SPLIT][f'd{idx}'] = {'text': code}
-            self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {f'd{idx}': 1}
+            if label == 1:
+                self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {f'd{idx}': 1}
+            else:
+                self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {}
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/CoSQARetrieval.py
+++ b/mteb/tasks/Retrieval/CoSQARetrieval.py
@@ -36,7 +36,7 @@ class CoSQARetrieval(AbsTaskRetrieval):
 
         for split in eval_splits:
             with tempfile.TemporaryDirectory() as tmp:
-                url = f"https://raw.githubusercontent.com/microsoft/CodeXGLUE/main/Text-Code/NL-code-search-WebQuery/CoSQA/cosqa-{split}.json"
+                url = f"https://raw.githubusercontent.com/microsoft/CodeXGLUE/e252e54a74dd55b1294e2379b213b1541dfefaf5/Text-Code/NL-code-search-WebQuery/CoSQA/cosqa-{split}.json"
                 test_file = os.path.join(tmp, "cosqa.json")
                 urllib.request.urlretrieve(url, test_file)
                 with open(test_file, "r") as f:

--- a/mteb/tasks/Retrieval/CoSQARetrieval.py
+++ b/mteb/tasks/Retrieval/CoSQARetrieval.py
@@ -29,6 +29,9 @@ class CoSQARetrieval(AbsTaskRetrieval):
 
         eval_splits = kwargs.get("eval_splits")
         eval_splits = eval_splits if eval_splits is not None else self.description["eval_splits"]
+        eval_splits = [split for split in eval_splits if split in self.description['eval_splits']]
+        if len(eval_splits) == 0:
+            eval_splits = ["dev"]
 
         self.queries = {split: {} for split in eval_splits}
         self.corpus = {split: {} for split in eval_splits}

--- a/mteb/tasks/Retrieval/CoSQARetrieval.py
+++ b/mteb/tasks/Retrieval/CoSQARetrieval.py
@@ -44,11 +44,9 @@ class CoSQARetrieval(AbsTaskRetrieval):
             code = row['code']
             query = row['doc']
             label = row['label']
-            self.queries[self._EVAL_SPLIT][f'q{idx}'] = query
             self.corpus[self._EVAL_SPLIT][f'd{idx}'] = {'text': code}
             if label == 1:
+                self.queries[self._EVAL_SPLIT][f'q{idx}'] = query
                 self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {f'd{idx}': 1}
-            else:
-                self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {}
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/CoSQARetrieval.py
+++ b/mteb/tasks/Retrieval/CoSQARetrieval.py
@@ -19,7 +19,7 @@ class CoSQARetrieval(AbsTaskRetrieval):
             "type": "Retrieval",
             "category": "s2p",
             "eval_splits": ["dev", "train"],
-            "eval_langs": ["en"],
+            "eval_langs": ["python"],
             "main_score": "mrr_at_10",
         }
 

--- a/mteb/tasks/Retrieval/CoSQARetrieval.py
+++ b/mteb/tasks/Retrieval/CoSQARetrieval.py
@@ -20,7 +20,7 @@ class CoSQARetrieval(AbsTaskRetrieval):
             "category": "s2p",
             "eval_splits": ["dev", "train"],
             "eval_langs": ["en"],
-            "main_score": "mrr",
+            "main_score": "mrr_at_10",
         }
 
     def load_data(self, **kwargs):

--- a/mteb/tasks/Retrieval/CoSQARetrieval.py
+++ b/mteb/tasks/Retrieval/CoSQARetrieval.py
@@ -5,13 +5,13 @@ import urllib.request
 from ...abstasks.AbsTaskRetrieval import AbsTaskRetrieval
 
 
-class WebQueryRetrieval(AbsTaskRetrieval):
-    _EVAL_SPLIT = 'test'
-    
+class CoSQARetrieval(AbsTaskRetrieval):
+    _EVAL_SPLIT = 'dev'
+
     @property
     def description(self):
         return {
-            'name': 'WebQueryRetrieval',
+            'name': 'CoSQARetrieval',
             'reference': 'https://github.com/microsoft/CodeXGLUE',
             "description": (
                 "Researchers from Microsoft Research Asia, Developer Division, and Bing introduce CodeXGLUE, "
@@ -20,7 +20,7 @@ class WebQueryRetrieval(AbsTaskRetrieval):
             ),
             "type": "Retrieval",
             "category": "s2p",
-            "eval_splits": ["test"],
+            "eval_splits": ["dev"],
             "eval_langs": ["en"],
             "main_score": "mrr",
         }
@@ -30,8 +30,8 @@ class WebQueryRetrieval(AbsTaskRetrieval):
             return
 
         with tempfile.TemporaryDirectory() as tmp:
-            url = "https://raw.githubusercontent.com/microsoft/CodeXGLUE/main/Text-Code/NL-code-search-WebQuery/data/test_webquery.json"
-            test_file = os.path.join(tmp, "test_webquery.json")
+            url = "https://raw.githubusercontent.com/microsoft/CodeXGLUE/main/Text-Code/NL-code-search-WebQuery/CoSQA/cosqa-dev.json"
+            test_file = os.path.join(tmp, "test_cosqa.json")
             urllib.request.urlretrieve(url, test_file)
             with open(test_file, "r") as f:
                 data = json.load(f)

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -1,11 +1,8 @@
 import tempfile
 import tokenize
-import tokenize
 import io
 import os
-import json
 import pandas as pd
-import shutil
 import zipfile
 import urllib.request
 from ...abstasks.AbsTaskRetrieval import AbsTaskRetrieval

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -75,12 +75,15 @@ class CodeSearchNetAdvRetrieval(AbsTaskRetrieval):
             urllib.request.urlretrieve(zenodo_url, python_zip_pth)
             with zipfile.ZipFile(python_zip_pth, 'r') as zip_ref:
                 zip_ref.extractall(python_dir)
-            os.system(f'cd {dset_dir} && python preprocess.py')
+            ret_code = os.system(f'cd {dset_dir} && python preprocess.py')
+            assert ret_code == 0, ret_code
 
             self.queries = {self._EVAL_SPLIT: {}}
             self.corpus = {self._EVAL_SPLIT: {}}
             self.relevant_docs = {self._EVAL_SPLIT: {}}
-            jsonObj = pd.read_json(path_or_buf=os.path.join(dset_dir, f'{self._EVAL_SPLIT}.jsonl'), lines=True)
+            data_path = os.path.join(dset_dir, f'{self._EVAL_SPLIT}.jsonl')
+            assert os.path.exists(data_path)
+            jsonObj = pd.read_json(path_or_buf=data_path, lines=True)
 
             for code, doc, lang, url, idx in zip(jsonObj['function'], jsonObj['docstring'], jsonObj['language'], jsonObj['url'], jsonObj['idx']):
                 self.queries[self._EVAL_SPLIT][url].append(f'[{lang}] {doc}')

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -50,7 +50,7 @@ class CodeSearchNetAdvRetrieval(AbsTaskRetrieval):
             "category": "s2p",
             "eval_splits": ["valid", "test"],
             "eval_langs": ["en"],
-            "main_score": "mrr",
+            "main_score": "mrr_at_10",
         }
 
     def load_data(self, **kwargs):

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -69,12 +69,12 @@ class CodeSearchNetAdvRetrieval(AbsTaskRetrieval):
             dset_dir = os.path.join(tmp, 'dataset')
             urllib.request.urlretrieve(dset_url, dset_zip_pth)
             with zipfile.ZipFile(dset_zip_pth, 'r') as zip_ref:
-                zip_ref.extractall()
+                zip_ref.extractall(tmp)
 
             python_zip_pth = os.path.join(dset_dir, "python.zip")
             urllib.request.urlretrieve(zenodo_url, python_zip_pth)
             with zipfile.ZipFile(python_zip_pth, 'r') as zip_ref:
-                zip_ref.extractall()
+                zip_ref.extractall(dset_dir)
             status = subprocess.run(['python', 'preprocess.py'], cwd=dset_dir, capture_output=True)
             assert status.returncode == 0, (status.stdout, status.stderr)
 

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -80,7 +80,7 @@ class CodeSearchNetAdvRetrieval(AbsTaskRetrieval):
             self.queries = {self._EVAL_SPLIT: {}}
             self.corpus = {self._EVAL_SPLIT: {}}
             self.relevant_docs = {self._EVAL_SPLIT: {}}
-            jsonObj = pd.read_json(path_or_buf=os.path.join(dset_dir, f'{self._EVAL_SPLIT}.json'), lines=True)
+            jsonObj = pd.read_json(path_or_buf=os.path.join(dset_dir, f'{self._EVAL_SPLIT}.jsonl'), lines=True)
 
             for code, doc, lang, url, idx in zip(jsonObj['function'], jsonObj['docstring'], jsonObj['language'], jsonObj['url'], jsonObj['idx']):
                 self.queries[self._EVAL_SPLIT][url].append(f'[{lang}] {doc}')

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -19,7 +19,6 @@ def remove_comments_and_docstrings(source):
         token_string = tok[1]
         start_line, start_col = tok[2]
         end_line, end_col = tok[3]
-        ltext = tok[4]
         if start_line > last_lineno:
             last_col = 0
         if start_col > last_col:
@@ -27,10 +26,8 @@ def remove_comments_and_docstrings(source):
         if token_type == tokenize.COMMENT:
             pass
         elif token_type == tokenize.STRING:
-            if prev_toktype != tokenize.INDENT:
-                if prev_toktype != tokenize.NEWLINE:
-                    if start_col > 0:
-                        out += token_string
+            if prev_toktype != tokenize.INDENT and prev_toktype != tokenize.NEWLINE and start_col > 0:
+                out += token_string
         else:
             out += token_string
         prev_toktype = token_type

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -77,7 +77,7 @@ class CodeSearchNetAdvRetrieval(AbsTaskRetrieval):
             with zipfile.ZipFile(python_zip_pth, 'r') as zip_ref:
                 zip_ref.extractall(python_dir)
             status = subprocess.run(['python', 'preprocess.py'], cwd=dset_dir)
-            status.check_returncode()
+            assert status.returncode == 0, (status.stdout, status.stderr)
 
             self.queries = {self._EVAL_SPLIT: {}}
             self.corpus = {self._EVAL_SPLIT: {}}

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -1,0 +1,93 @@
+import tempfile
+import tokenize
+import tokenize
+import io
+import os
+import json
+import pandas as pd
+import shutil
+import zipfile
+import urllib.request
+from ...abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+def remove_comments_and_docstrings(source):
+    io_obj = io.StringIO(source)
+    out = ""
+    prev_toktype = tokenize.INDENT
+    last_lineno = -1
+    last_col = 0
+    for tok in tokenize.generate_tokens(io_obj.readline):
+        token_type = tok[0]
+        token_string = tok[1]
+        start_line, start_col = tok[2]
+        end_line, end_col = tok[3]
+        ltext = tok[4]
+        if start_line > last_lineno:
+            last_col = 0
+        if start_col > last_col:
+            out += (" " * (start_col - last_col))
+        if token_type == tokenize.COMMENT:
+            pass
+        elif token_type == tokenize.STRING:
+            if prev_toktype != tokenize.INDENT:
+                if prev_toktype != tokenize.NEWLINE:
+                    if start_col > 0:
+                        out += token_string
+        else:
+            out += token_string
+        prev_toktype = token_type
+        last_col = end_col
+        last_lineno = end_line
+    out = '\n'.join(l for l in out.splitlines() if l.strip())
+    return out
+
+
+class CodeSearchNetAdvRetrieval(AbsTaskRetrieval):
+    _EVAL_SPLIT = 'valid'
+
+    @property
+    def description(self):
+        return {
+            'name': 'CodeSearchNetAdvRetrieval',
+            'reference': 'https://github.com/github/CodeSearchNet',
+            "description": (
+                "CodeSearchNet is a collection of datasets and benchmarks that explore the problem of code retrieval using natural language."
+            ),
+            "type": "Retrieval",
+            "category": "s2p",
+            "eval_splits": ["valid", "test"],
+            "eval_langs": ["en"],
+            "main_score": "mrr",
+        }
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dset_url = "https://github.com/microsoft/CodeXGLUE/raw/main/Text-Code/NL-code-search-Adv/dataset.zip"
+            zenodo_url = "https://zenodo.org/record/7857872/files/python.zip"
+            dset_zip_pth = os.path.join(tmp, 'dataset.zip')
+            dset_dir = os.path.join(tmp, 'dataset')
+            urllib.request.urlretrieve(dset_url, dset_zip_pth)
+            with zipfile.ZipFile(dset_zip_pth, 'r') as zip_ref:
+                zip_ref.extractall(dset_dir)
+
+            python_zip_pth = os.path.join(dset_dir, "python.zip")
+            python_dir = os.path.join(dset_dir, "python")
+            urllib.request.urlretrieve(zenodo_url, python_zip_pth)
+            with zipfile.ZipFile(python_zip_pth, 'r') as zip_ref:
+                zip_ref.extractall(python_dir)
+            os.system(f'cd {dset_dir} && python preprocess.py')
+
+            self.queries = {self._EVAL_SPLIT: {}}
+            self.corpus = {self._EVAL_SPLIT: {}}
+            self.relevant_docs = {self._EVAL_SPLIT: {}}
+            jsonObj = pd.read_json(path_or_buf=os.path.join(dset_dir, f'{self._EVAL_SPLIT}.json'), lines=True)
+
+            for code, doc, lang, url, idx in zip(jsonObj['function'], jsonObj['docstring'], jsonObj['language'], jsonObj['url'], jsonObj['idx']):
+                self.queries[self._EVAL_SPLIT][url].append(doc)
+                self.corpus[self._EVAL_SPLIT][str(idx)] = {'text': remove_comments_and_docstrings(code)}
+                self.relevant_docs[self._EVAL_SPLIT][url] = {str(idx): 1}
+
+        self.data_loaded = True

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -49,7 +49,7 @@ class CodeSearchNetAdvRetrieval(AbsTaskRetrieval):
             "type": "Retrieval",
             "category": "s2p",
             "eval_splits": ["valid", "test"],
-            "eval_langs": ["en"],
+            "eval_langs": ["python"],
             "main_score": "mrr_at_10",
         }
 

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -2,6 +2,7 @@ import tempfile
 import tokenize
 import io
 import os
+import subprocess
 import pandas as pd
 import zipfile
 import urllib.request
@@ -75,7 +76,7 @@ class CodeSearchNetAdvRetrieval(AbsTaskRetrieval):
             urllib.request.urlretrieve(zenodo_url, python_zip_pth)
             with zipfile.ZipFile(python_zip_pth, 'r') as zip_ref:
                 zip_ref.extractall(python_dir)
-            ret_code = os.system(f'cd {dset_dir} && python preprocess.py')
+            ret_code = subprocess.run(['python', 'preprocess.py'], cwd=dset_dir).returncode
             assert ret_code == 0, ret_code
 
             self.queries = {self._EVAL_SPLIT: {}}

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -76,8 +76,8 @@ class CodeSearchNetAdvRetrieval(AbsTaskRetrieval):
             urllib.request.urlretrieve(zenodo_url, python_zip_pth)
             with zipfile.ZipFile(python_zip_pth, 'r') as zip_ref:
                 zip_ref.extractall(python_dir)
-            ret_code = subprocess.run(['python', 'preprocess.py'], cwd=dset_dir).returncode
-            assert ret_code == 0, ret_code
+            status = subprocess.run(['python', 'preprocess.py'], cwd=dset_dir)
+            status.check_returncode()
 
             self.queries = {self._EVAL_SPLIT: {}}
             self.corpus = {self._EVAL_SPLIT: {}}

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -86,7 +86,7 @@ class CodeSearchNetAdvRetrieval(AbsTaskRetrieval):
             jsonObj = pd.read_json(path_or_buf=data_path, lines=True)
 
             for code, doc, lang, url, idx in zip(jsonObj['function'], jsonObj['docstring'], jsonObj['language'], jsonObj['url'], jsonObj['idx']):
-                self.queries[self._EVAL_SPLIT][url].append(f'[{lang}] {doc}')
+                self.queries[self._EVAL_SPLIT][url] = f'[{lang}] {doc}'
                 self.corpus[self._EVAL_SPLIT][str(idx)] = {'text': remove_comments_and_docstrings(code)}
                 self.relevant_docs[self._EVAL_SPLIT][url] = {str(idx): 1}
 

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -61,7 +61,7 @@ class CodeSearchNetAdvRetrieval(AbsTaskRetrieval):
         eval_splits = eval_splits if eval_splits is not None else self.description["eval_splits"]
 
         with tempfile.TemporaryDirectory() as tmp:
-            dset_url = "https://github.com/microsoft/CodeXGLUE/raw/main/Text-Code/NL-code-search-Adv/dataset.zip"
+            dset_url = "https://github.com/microsoft/CodeXGLUE/blob/e252e54a74dd55b1294e2379b213b1541dfefaf5/Text-Code/NL-code-search-Adv/dataset.zip"
             zenodo_url = "https://zenodo.org/record/7857872/files/python.zip"
             dset_zip_pth = os.path.join(tmp, 'dataset.zip')
             dset_dir = os.path.join(tmp, 'dataset')

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -76,7 +76,7 @@ class CodeSearchNetAdvRetrieval(AbsTaskRetrieval):
             urllib.request.urlretrieve(zenodo_url, python_zip_pth)
             with zipfile.ZipFile(python_zip_pth, 'r') as zip_ref:
                 zip_ref.extractall(python_dir)
-            status = subprocess.run(['python', 'preprocess.py'], cwd=dset_dir)
+            status = subprocess.run(['python', 'preprocess.py'], cwd=dset_dir, capture_output=True)
             assert status.returncode == 0, (status.stdout, status.stderr)
 
             self.queries = {self._EVAL_SPLIT: {}}

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -83,7 +83,7 @@ class CodeSearchNetAdvRetrieval(AbsTaskRetrieval):
             jsonObj = pd.read_json(path_or_buf=os.path.join(dset_dir, f'{self._EVAL_SPLIT}.json'), lines=True)
 
             for code, doc, lang, url, idx in zip(jsonObj['function'], jsonObj['docstring'], jsonObj['language'], jsonObj['url'], jsonObj['idx']):
-                self.queries[self._EVAL_SPLIT][url].append(doc)
+                self.queries[self._EVAL_SPLIT][url].append(f'[{lang}] {doc}')
                 self.corpus[self._EVAL_SPLIT][str(idx)] = {'text': remove_comments_and_docstrings(code)}
                 self.relevant_docs[self._EVAL_SPLIT][url] = {str(idx): 1}
 

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -8,7 +8,7 @@ import zipfile
 import urllib.request
 from ...abstasks.AbsTaskRetrieval import AbsTaskRetrieval
 
-def remove_comments_and_docstrings(source):
+def remove_comments_and_docstrings(source, remove_comments=True):
     io_obj = io.StringIO(source)
     out = ""
     prev_toktype = tokenize.INDENT
@@ -23,7 +23,7 @@ def remove_comments_and_docstrings(source):
             last_col = 0
         if start_col > last_col:
             out += (" " * (start_col - last_col))
-        if token_type == tokenize.COMMENT:
+        if token_type == tokenize.COMMENT and remove_comments:
             pass
         elif token_type == tokenize.STRING:
             if prev_toktype != tokenize.INDENT and prev_toktype != tokenize.NEWLINE and start_col > 0:

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -69,13 +69,12 @@ class CodeSearchNetAdvRetrieval(AbsTaskRetrieval):
             dset_dir = os.path.join(tmp, 'dataset')
             urllib.request.urlretrieve(dset_url, dset_zip_pth)
             with zipfile.ZipFile(dset_zip_pth, 'r') as zip_ref:
-                zip_ref.extractall(dset_dir)
+                zip_ref.extractall()
 
             python_zip_pth = os.path.join(dset_dir, "python.zip")
-            python_dir = os.path.join(dset_dir, "python")
             urllib.request.urlretrieve(zenodo_url, python_zip_pth)
             with zipfile.ZipFile(python_zip_pth, 'r') as zip_ref:
-                zip_ref.extractall(python_dir)
+                zip_ref.extractall()
             status = subprocess.run(['python', 'preprocess.py'], cwd=dset_dir, capture_output=True)
             assert status.returncode == 0, (status.stdout, status.stderr)
 

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -61,7 +61,7 @@ class CodeSearchNetAdvRetrieval(AbsTaskRetrieval):
         eval_splits = eval_splits if eval_splits is not None else self.description["eval_splits"]
 
         with tempfile.TemporaryDirectory() as tmp:
-            dset_url = "https://github.com/microsoft/CodeXGLUE/blob/e252e54a74dd55b1294e2379b213b1541dfefaf5/Text-Code/NL-code-search-Adv/dataset.zip"
+            dset_url = "https://github.com/microsoft/CodeXGLUE/raw/e252e54a74dd55b1294e2379b213b1541dfefaf5/Text-Code/NL-code-search-Adv/dataset.zip"
             zenodo_url = "https://zenodo.org/record/7857872/files/python.zip"
             dset_zip_pth = os.path.join(tmp, 'dataset.zip')
             dset_dir = os.path.join(tmp, 'dataset')

--- a/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetAdvRetrieval.py
@@ -84,8 +84,8 @@ class CodeSearchNetAdvRetrieval(AbsTaskRetrieval):
                 assert os.path.exists(data_path)
                 jsonObj = pd.read_json(path_or_buf=data_path, lines=True)
 
-                for code, doc, lang, url, idx in zip(jsonObj['function'], jsonObj['docstring'], jsonObj['language'], jsonObj['url'], jsonObj['idx']):
-                    self.queries[split][url] = f'[{lang}] {doc}'
+                for code, doc, url, idx in zip(jsonObj['function'], jsonObj['docstring'], jsonObj['url'], jsonObj['idx']):
+                    self.queries[split][url] = doc
                     self.corpus[split][str(idx)] = {'text': remove_comments_and_docstrings(code)}
                     self.relevant_docs[split][url] = {str(idx): 1}
 

--- a/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
@@ -65,7 +65,6 @@ class CodeSearchNetQueryRetrieval(AbsTaskRetrieval):
                         filtered_ground_truth.append((query, url, relevance))
 
         distinct_queries = set(row[0] for row in filtered_ground_truth)
-        print(distinct_queries)
         for idx, query in enumerate(distinct_queries):
             self.queries[self._EVAL_SPLIT][f'q{idx}'] = query
             self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {}

--- a/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
@@ -65,7 +65,8 @@ class CodeSearchNetQueryRetrieval(AbsTaskRetrieval, MultilingualTask):
             self.relevant_docs[lang] = {}
             print(f'Loading data for {lang}')
             for split in eval_splits:
-                data = datasets.load_dataset(self.description['hf_hub_name'], split=lang)
+                hf_ds_name = 'jinaai/code_search_net_dedupe_only_annotated' if skip_unannotated else 'jinaai/code_search_net_dedupe'
+                data = datasets.load_dataset(hf_ds_name, split=lang)
                 self.queries[lang][split] = {}
                 self.corpus[lang][split] = {}
                 self.relevant_docs[lang][split] = {}
@@ -73,8 +74,7 @@ class CodeSearchNetQueryRetrieval(AbsTaskRetrieval, MultilingualTask):
                 url_to_id = {}
                 for idx, row in tqdm(enumerate(data), total=len(data)):
                     url = row['url']
-                    if url not in annotated_urls and skip_unannotated:
-                        continue
+                    assert url in annotated_urls or not skip_unannotated
                     code = filter_docs(row['docstring'], row['function'], lang)
                     self.corpus[lang][split][f'd{idx}'] = {'text': code}
                     url_to_id[url] = f'd{idx}'

--- a/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
@@ -58,7 +58,6 @@ class CodeSearchNetQueryRetrieval(AbsTaskRetrieval):
             with open(data_path, 'r') as f:
                 reader = csv.reader(f)
                 for row in islice(reader, 1, None):
-                    print(row)
                     lang, query, url, relevance, _ = row
                     relevance = int(relevance)
                     if lang.lower() == self._EVAL_SPLIT and relevance > 0:

--- a/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
@@ -7,7 +7,7 @@ import urllib.request
 import csv
 from itertools import islice
 
-class CodeSearchNetRetrieval(AbsTaskRetrieval):
+class CodeSearchNetQueryRetrieval(AbsTaskRetrieval):
     _EVAL_SPLIT = 'python'
 
     @property

--- a/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
@@ -50,6 +50,10 @@ class CodeSearchNetQueryRetrieval(AbsTaskRetrieval, MultilingualTask):
                 reader = csv.reader(f)
                 annotation_store = list(reader)
 
+        self.queries = {}
+        self.corpus = {}
+        self.relevant_docs = {}
+        
         for lang in self.langs:
             self.queries[lang] = {}
             self.corpus[lang] = {}

--- a/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
@@ -32,7 +32,7 @@ class CodeSearchNetQueryRetrieval(AbsTaskRetrieval):
             "category": "s2p",
             "eval_splits": ["python", "java", "javascript", "go", "php", "ruby"],
             "eval_langs": ["en"],
-            "main_score": "mrr",
+            "main_score": "mrr_at_10",
         }
 
     def load_data(self, **kwargs):

--- a/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
@@ -58,11 +58,13 @@ class CodeSearchNetQueryRetrieval(AbsTaskRetrieval):
             with open(data_path, 'r') as f:
                 reader = csv.reader(f)
                 for row in islice(reader, 1, None):
+                    print(row)
                     lang, query, url, relevance, _ = row
-                    if lang == self._EVAL_SPLIT and relevance > 0:
+                    if lang.lower() == self._EVAL_SPLIT and relevance > 0:
                         filtered_ground_truth.append((query, url, relevance))
 
         distinct_queries = set(row[0] for row in filtered_ground_truth)
+        print(distinct_queries)
         for idx, query in enumerate(distinct_queries):
             self.queries[self._EVAL_SPLIT][f'q{idx}'] = query
             self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {}

--- a/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
@@ -1,5 +1,6 @@
 import datasets
 from ...abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+from ...abstasks.MultilingualTask import MultilingualTask
 import tempfile
 import os
 import urllib.request

--- a/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
@@ -60,6 +60,7 @@ class CodeSearchNetQueryRetrieval(AbsTaskRetrieval):
                 for row in islice(reader, 1, None):
                     print(row)
                     lang, query, url, relevance, _ = row
+                    relevance = int(relevance)
                     if lang.lower() == self._EVAL_SPLIT and relevance > 0:
                         filtered_ground_truth.append((query, url, relevance))
 

--- a/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
@@ -28,7 +28,7 @@ class CodeSearchNetQueryRetrieval(AbsTaskRetrieval, MultilingualTask):
             ),
             "type": "Retrieval",
             "category": "s2p",
-            "eval_splits": ["test", ],
+            "eval_splits": ["test"],
             "eval_langs": ["python", "java", "javascript", "go", "php", "ruby"],
             "main_score": "mrr_at_10",
         }

--- a/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
@@ -1,0 +1,64 @@
+import datasets
+from ...abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+from .CodeSearchNetAdvRetrieval import remove_comments_and_docstrings
+import tempfile
+import os
+import urllib.request
+import csv
+from itertools import islice
+
+class CodeSearchNetRetrieval(AbsTaskRetrieval):
+    _EVAL_SPLIT = 'python'
+
+    @property
+    def description(self):
+        return {
+            'name': 'CodeSearchNetRetrieval',
+            'hf_hub_name': 'jinaai/code_search_net_dedupe',
+            'reference': 'https://github.com/github/CodeSearchNet',
+            "description": (
+                "CodeSearchNet is a collection of datasets and benchmarks that explore the problem of code retrieval using natural language."
+            ),
+            "type": "Retrieval",
+            "category": "s2p",
+            "eval_splits": ["python", "java", "javascript", "go", "php", "ruby"],
+            "eval_langs": ["en"],
+            "main_score": "mrr",
+        }
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        data = datasets.load_dataset(self.description['hf_hub_name'], split=self._EVAL_SPLIT)
+        self.queries = {self._EVAL_SPLIT: {}}
+        self.corpus = {self._EVAL_SPLIT: {}}
+        self.relevant_docs = {self._EVAL_SPLIT: {}}
+
+        url_to_id = {}
+        for idx, row in enumerate(data):
+            code = remove_comments_and_docstrings(row['function'], remove_comments=False)
+            self.corpus[self._EVAL_SPLIT][f'd{idx}'] = code
+            url_to_id[row['url']] = f'd{idx}'
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            annotation_url = 'https://raw.githubusercontent.com/github/CodeSearchNet/master/resources/annotationStore.csv'
+            data_path = os.path.join(tmpdir, 'annotationStore.csv')
+            urllib.request.urlretrieve(annotation_url, data_path)
+            filtered_ground_truth = []
+            with open(data_path, 'r') as f:
+                reader = csv.reader(f)
+                for row in islice(reader, 1, None):
+                    lang, query, url, relevance, _ = row
+                    if lang == self._EVAL_SPLIT and relevance > 0:
+                        filtered_ground_truth.append((query, url, relevance))
+
+        distinct_queries = set(row[0] for row in filtered_ground_truth)
+        for idx, query in enumerate(distinct_queries):
+            self._queries[self._EVAL_SPLIT][f'q{idx}'] = query
+            self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {}
+            relevant_docs = filter(lambda row: row[0] == query, filtered_ground_truth)
+            for _, url, relevance in relevant_docs:
+                self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'][url_to_id[url]] = relevance
+
+        self.data_loaded = True

--- a/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
@@ -13,7 +13,7 @@ class CodeSearchNetQueryRetrieval(AbsTaskRetrieval):
     @property
     def description(self):
         return {
-            'name': 'CodeSearchNetRetrieval',
+            'name': 'CodeSearchNetQueryRetrieval',
             'hf_hub_name': 'jinaai/code_search_net_dedupe',
             'reference': 'https://github.com/github/CodeSearchNet',
             "description": (

--- a/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
@@ -64,7 +64,7 @@ class CodeSearchNetQueryRetrieval(AbsTaskRetrieval):
 
         distinct_queries = set(row[0] for row in filtered_ground_truth)
         for idx, query in enumerate(distinct_queries):
-            self._queries[self._EVAL_SPLIT][f'q{idx}'] = query
+            self.queries[self._EVAL_SPLIT][f'q{idx}'] = query
             self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {}
             relevant_docs = filter(lambda row: row[0] == query, filtered_ground_truth)
             for _, url, relevance in relevant_docs:

--- a/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
@@ -1,11 +1,20 @@
 import datasets
 from ...abstasks.AbsTaskRetrieval import AbsTaskRetrieval
-from .CodeSearchNetAdvRetrieval import remove_comments_and_docstrings
 import tempfile
 import os
 import urllib.request
 import csv
 from itertools import islice
+
+def _filter_docs(docs, code, lang):
+    if docs in code:
+        if lang == 'python':
+            start_doc = code.find('"""')
+            end_doc = code.find('"""', start_doc + 1)
+            code = code[:start_doc] + code[end_doc + 3:]
+        else:
+            return None
+    return code
 
 class CodeSearchNetQueryRetrieval(AbsTaskRetrieval):
     _EVAL_SPLIT = 'python'
@@ -37,7 +46,7 @@ class CodeSearchNetQueryRetrieval(AbsTaskRetrieval):
 
         url_to_id = {}
         for idx, row in enumerate(data):
-            code = remove_comments_and_docstrings(row['function'], remove_comments=False)
+            code = _filter_docs(row['docstring'], row['function'], self._EVAL_SPLIT)
             self.corpus[self._EVAL_SPLIT][f'd{idx}'] = {'text': code}
             url_to_id[row['url']] = f'd{idx}'
 

--- a/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
@@ -11,7 +11,7 @@ def _filter_docs(docs, code, lang):
         if lang == 'python':
             start_doc = code.find('"""')
             end_doc = code.find('"""', start_doc + 1)
-            code = code[:start_doc] + code[end_doc + 3:]
+            code = code[:start_doc].rstrip(' ') + code[end_doc + 3:].lstrip('\n')
         else:
             return None
     return code

--- a/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetQueryRetrieval.py
@@ -38,7 +38,7 @@ class CodeSearchNetRetrieval(AbsTaskRetrieval):
         url_to_id = {}
         for idx, row in enumerate(data):
             code = remove_comments_and_docstrings(row['function'], remove_comments=False)
-            self.corpus[self._EVAL_SPLIT][f'd{idx}'] = code
+            self.corpus[self._EVAL_SPLIT][f'd{idx}'] = {'text': code}
             url_to_id[row['url']] = f'd{idx}'
 
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
@@ -43,6 +43,7 @@ class CodeSearchNetRetrieval(AbsTaskRetrieval, MultilingualTask):
                 for idx, row in enumerate(data):
                     code = row['code']
                     query = row['doc']
+                    assert isinstance(code, str) and isinstance(query, str), (code, query)
                     self.queries[lang][split][f'q{idx}'] = query
                     self.corpus[lang][split][f'd{idx}'] = {'text': code}
                     self.relevant_docs[lang][split][f'q{idx}'] = {f'd{idx}': 1}

--- a/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
@@ -44,7 +44,7 @@ class CodeSearchNetRetrieval(AbsTaskRetrieval, MultilingualTask):
                 data = datasets.load_dataset(self.description['hf_hub_name'], split=f'{split}.{lang}')
                 for idx, row in enumerate(data):
                     code = row['code']
-                    query = row['queries']
+                    query = row['doc']
                     self.queries[lang][split][f'q{idx}'] = query
                     self.corpus[lang][split][f'd{idx}'] = {'text': code}
                     self.relevant_docs[lang][split][f'q{idx}'] = {f'd{idx}': 1}

--- a/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
@@ -33,14 +33,14 @@ class CodeSearchNetRetrieval(AbsTaskRetrieval):
         d = set()
         for idx, row in enumerate(data):
             code = row['code']
-            docs = row['docs']
-            if docs in q:
+            query = row['docs']
+            if query in q:
                 continue
             if code in d:
                 continue
-            q.add(docs)
+            q.add(query)
             d.add(code)
-            self.queries[self._EVAL_SPLIT][f'q{idx}'] = docs
+            self.queries[self._EVAL_SPLIT][f'q{idx}'] = query
             self.corpus[self._EVAL_SPLIT][f'd{idx}'] = {'text': code}
             self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {f'd{idx}': 1}
 

--- a/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
@@ -17,7 +17,7 @@ class CodeSearchNetRetrieval(AbsTaskRetrieval, MultilingualTask):
             "category": "s2p",
             "eval_splits": ["validation", "test"],
             "eval_langs": ["go", "java", "javascript", "php", "python", "ruby"],
-            "main_score": "mrr",
+            "main_score": "mrr_at_10",
         }
 
     def load_data(self, **kwargs):

--- a/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
@@ -42,7 +42,7 @@ class CodeSearchNetRetrieval(AbsTaskRetrieval):
             q.add(row['func_documentation_string'])
             d.add(row['func_code_string'])
             self.queries[self._EVAL_SPLIT][f'q{idx}'] = row['func_documentation_string']
-            self.corpus[self._EVAL_SPLIT][f'd{idx}'] = row['func_code_string']
+            self.corpus[self._EVAL_SPLIT][f'd{idx}'] = {'text': row['func_code_string']}
             self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {f'd{idx}': 1}
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
@@ -16,7 +16,7 @@ class CodeSearchNetRetrieval(AbsTaskRetrieval, MultilingualTask):
             "type": "Retrieval",
             "category": "s2p",
             "eval_splits": ["validation", "test"],
-            "eval_langs": ["en"],
+            "eval_langs": ["go", "java", "javascript", "php", "python", "ruby"],
             "main_score": "mrr",
         }
 
@@ -32,6 +32,8 @@ class CodeSearchNetRetrieval(AbsTaskRetrieval, MultilingualTask):
         self.relevant_docs = {}
 
         for lang in self.langs:
+            if lang not in self.description['eval_langs']:
+                continue
             self.queries[lang] = {}
             self.corpus[lang] = {}
             self.relevant_docs[lang] = {}

--- a/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
@@ -33,7 +33,7 @@ class CodeSearchNetRetrieval(AbsTaskRetrieval):
         d = set()
         for idx, row in enumerate(data):
             func_doc_string = row['func_documentation_string']
-            if func_doc_string == '' or func_doc_string.split()  <= 3:
+            if func_doc_string == '' or len(func_doc_string.split())  <= 3:
                 continue
             if row['func_documentation_string'] in q:
                 continue

--- a/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
@@ -32,16 +32,16 @@ class CodeSearchNetRetrieval(AbsTaskRetrieval):
         q = set()
         d = set()
         for idx, row in enumerate(data):
-            func_doc_string = row['func_documentation_string']
-            if func_doc_string == '' or len(func_doc_string.split())  <= 3:
+            func_doc_tokens = ' '.join(row['func_documentation_tokens'])
+            if func_doc_tokens == '' or len(row['func_documentation_tokens']) <= 3:
                 continue
-            if row['func_documentation_string'] in q:
+            if func_doc_tokens in q:
                 continue
             if row['func_code_string'] in d:
                 continue
-            q.add(row['func_documentation_string'])
+            q.add(func_doc_tokens)
             d.add(row['func_code_string'])
-            self.queries[self._EVAL_SPLIT][f'q{idx}'] = row['func_documentation_string']
+            self.queries[self._EVAL_SPLIT][f'q{idx}'] = func_doc_tokens
             self.corpus[self._EVAL_SPLIT][f'd{idx}'] = {'text': row['func_code_string']}
             self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {f'd{idx}': 1}
 

--- a/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
@@ -2,7 +2,7 @@ import datasets
 from ...abstasks.AbsTaskRetrieval import AbsTaskRetrieval
 
 
-class NarrativeQARetrieval(AbsTaskRetrieval):
+class CodeSearchNetRetrieval(AbsTaskRetrieval):
     _EVAL_SPLIT = 'test'
 
     @property
@@ -32,6 +32,9 @@ class NarrativeQARetrieval(AbsTaskRetrieval):
         q = set()
         d = set()
         for idx, row in enumerate(data):
+            func_doc_string = row['func_documentation_string']
+            if func_doc_string == '' or func_doc_string.split()  <= 3:
+                continue
             if row['func_documentation_string'] in q:
                 continue
             if row['func_code_string'] in d:

--- a/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
@@ -29,17 +29,9 @@ class CodeSearchNetRetrieval(AbsTaskRetrieval):
         self.queries = {self._EVAL_SPLIT: {}}
         self.corpus = {self._EVAL_SPLIT: {}}
         self.relevant_docs = {self._EVAL_SPLIT: {}}
-        q = set()
-        d = set()
         for idx, row in enumerate(data):
             code = row['code']
-            query = row['docs']
-            if query in q:
-                continue
-            if code in d:
-                continue
-            q.add(query)
-            d.add(code)
+            query = row['queries']
             self.queries[self._EVAL_SPLIT][f'q{idx}'] = query
             self.corpus[self._EVAL_SPLIT][f'd{idx}'] = {'text': code}
             self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {f'd{idx}': 1}

--- a/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
@@ -1,0 +1,45 @@
+import datasets
+from ...abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class NarrativeQARetrieval(AbsTaskRetrieval):
+    _EVAL_SPLIT = 'test'
+
+    @property
+    def description(self):
+        return {
+            'name': 'CodeSearchNetRetrieval',
+            'hf_hub_name': 'code_search_net',
+            'reference': 'https://github.com/github/CodeSearchNet',
+            "description": (
+                "CodeSearchNet is a collection of datasets and benchmarks that explore the problem of code retrieval using natural language."
+            ),
+            "type": "Retrieval",
+            "category": "s2p",
+            "eval_splits": ["test"],
+            "eval_langs": ["en"],
+            "main_score": "mrr",
+        }
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        data = datasets.load_dataset(self.description['hf_hub_name'], split=self._EVAL_SPLIT)
+        self.queries = {self._EVAL_SPLIT: {}}
+        self.corpus = {self._EVAL_SPLIT: {}}
+        self.relevant_docs = {self._EVAL_SPLIT: {}}
+        q = set()
+        d = set()
+        for idx, row in enumerate(data):
+            if row['func_documentation_string'] in q:
+                continue
+            if row['func_code_string'] in d:
+                continue
+            q.add(row['func_documentation_string'])
+            d.add(row['func_code_string'])
+            self.queries[self._EVAL_SPLIT][f'q{idx}'] = row['func_documentation_string']
+            self.corpus[self._EVAL_SPLIT][f'd{idx}'] = row['func_code_string']
+            self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {f'd{idx}': 1}
+
+        self.data_loaded = True

--- a/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
@@ -9,7 +9,7 @@ class CodeSearchNetRetrieval(AbsTaskRetrieval):
     def description(self):
         return {
             'name': 'CodeSearchNetRetrieval',
-            'hf_hub_name': 'code_search_net',
+            'hf_hub_name': 'jinaai/code_search_net_clean',
             'reference': 'https://github.com/github/CodeSearchNet',
             "description": (
                 "CodeSearchNet is a collection of datasets and benchmarks that explore the problem of code retrieval using natural language."
@@ -32,17 +32,16 @@ class CodeSearchNetRetrieval(AbsTaskRetrieval):
         q = set()
         d = set()
         for idx, row in enumerate(data):
-            func_doc_tokens = ' '.join(row['func_documentation_tokens'])
-            if func_doc_tokens == '' or len(row['func_documentation_tokens']) <= 3:
+            code = row['code']
+            docs = row['docs']
+            if docs in q:
                 continue
-            if func_doc_tokens in q:
+            if code in d:
                 continue
-            if row['func_code_string'] in d:
-                continue
-            q.add(func_doc_tokens)
-            d.add(row['func_code_string'])
-            self.queries[self._EVAL_SPLIT][f'q{idx}'] = func_doc_tokens
-            self.corpus[self._EVAL_SPLIT][f'd{idx}'] = {'text': row['func_code_string']}
+            q.add(docs)
+            d.add(code)
+            self.queries[self._EVAL_SPLIT][f'q{idx}'] = docs
+            self.corpus[self._EVAL_SPLIT][f'd{idx}'] = {'text': code}
             self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {f'd{idx}': 1}
 
         self.data_loaded = True

--- a/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
@@ -32,8 +32,6 @@ class CodeSearchNetRetrieval(AbsTaskRetrieval, MultilingualTask):
         self.relevant_docs = {}
 
         for lang in self.langs:
-            if lang not in self.description['eval_langs']:
-                continue
             self.queries[lang] = {}
             self.corpus[lang] = {}
             self.relevant_docs[lang] = {}

--- a/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
+++ b/mteb/tasks/Retrieval/CodeSearchNetRetrieval.py
@@ -39,7 +39,7 @@ class CodeSearchNetRetrieval(AbsTaskRetrieval, MultilingualTask):
                 self.queries[lang][split] = {}
                 self.corpus[lang][split] = {}
                 self.relevant_docs[lang][split] = {}
-                data = datasets.load_dataset(self.description['hf_hub_name'], split=f'{split}.{language}')
+                data = datasets.load_dataset(self.description['hf_hub_name'], split=f'{split}.{lang}')
                 for idx, row in enumerate(data):
                     code = row['code']
                     query = row['queries']

--- a/mteb/tasks/Retrieval/WebQueryRetrieval.py
+++ b/mteb/tasks/Retrieval/WebQueryRetrieval.py
@@ -1,0 +1,50 @@
+import tempfile
+import json
+import os
+import urllib.request
+from ...abstasks.AbsTaskRetrieval import AbsTaskRetrieval
+
+
+class WebQueryRetrieval(AbsTaskRetrieval):
+    _EVAL_SPLIT = 'test'
+    
+    @property
+    def description(self):
+        return {
+            'name': 'WebQueryRetrieval',
+            'reference': 'https://github.com/microsoft/CodeXGLUE',
+            "description": (
+                "Researchers from Microsoft Research Asia, Developer Division, and Bing introduce CodeXGLUE, "
+                "a benchmark dataset and open challenge for code intelligence. "
+                "It includes a collection of code intelligence tasks and a platform for model evaluation and comparison."
+            ),
+            "type": "Retrieval",
+            "category": "s2p",
+            "eval_splits": ["test"],
+            "eval_langs": ["en"],
+            "main_score": "mrr",
+        }
+
+    def load_data(self, **kwargs):
+        if self.data_loaded:
+            return
+
+        with tempfile.TemporaryDirectory() as tmp:
+            url = "https://raw.githubusercontent.com/microsoft/CodeXGLUE/main/Text-Code/NL-code-search-WebQuery/data/test_webquery.json"
+            test_file = os.path.join(tmp, "test_webquery.json")
+            urllib.request.urlretrieve(url, test_file)
+            with open(test_file, "r") as f:
+                data = json.load(f)
+            os.remove(test_file)
+
+        self.queries = {self._EVAL_SPLIT: {}}
+        self.corpus = {self._EVAL_SPLIT: {}}
+        self.relevant_docs = {self._EVAL_SPLIT: {}}
+        for idx, row in enumerate(data):
+            code = row['code']
+            query = row['doc']
+            self.queries[self._EVAL_SPLIT][f'q{idx}'] = query
+            self.corpus[self._EVAL_SPLIT][f'd{idx}'] = {'text': code}
+            self.relevant_docs[self._EVAL_SPLIT][f'q{idx}'] = {f'd{idx}': 1}
+
+        self.data_loaded = True

--- a/mteb/tasks/Retrieval/__init__.py
+++ b/mteb/tasks/Retrieval/__init__.py
@@ -41,3 +41,4 @@ from .NarrativeQARetrieval import *
 from .CodeSearchNetRetrieval import *
 from .CoSQARetrieval import *
 from .CodeSearchNetAdvRetrieval import *
+from .CodeSearchNetQueryRetrieval import *

--- a/mteb/tasks/Retrieval/__init__.py
+++ b/mteb/tasks/Retrieval/__init__.py
@@ -38,3 +38,4 @@ from .SCIDOCSPLRetrieval import *
 from .SciFactPLRetrieval import *
 from .TRECCOVIDPLRetrieval import *
 from .NarrativeQARetrieval import *
+from .CodeSearchNetRetrieval import *

--- a/mteb/tasks/Retrieval/__init__.py
+++ b/mteb/tasks/Retrieval/__init__.py
@@ -39,4 +39,4 @@ from .SciFactPLRetrieval import *
 from .TRECCOVIDPLRetrieval import *
 from .NarrativeQARetrieval import *
 from .CodeSearchNetRetrieval import *
-from .WebQueryRetrieval import *
+from .CoSQARetrieval import *

--- a/mteb/tasks/Retrieval/__init__.py
+++ b/mteb/tasks/Retrieval/__init__.py
@@ -39,3 +39,4 @@ from .SciFactPLRetrieval import *
 from .TRECCOVIDPLRetrieval import *
 from .NarrativeQARetrieval import *
 from .CodeSearchNetRetrieval import *
+from .WebQueryRetrieval import *

--- a/mteb/tasks/Retrieval/__init__.py
+++ b/mteb/tasks/Retrieval/__init__.py
@@ -40,3 +40,4 @@ from .TRECCOVIDPLRetrieval import *
 from .NarrativeQARetrieval import *
 from .CodeSearchNetRetrieval import *
 from .CoSQARetrieval import *
+from .CodeSearchNetAdvRetrieval import *


### PR DESCRIPTION
add code search net test set to MTEB eval, use `func_documentation_tokens ` to search `func_code_string`, each docstring has only 1 match code.

I also filtered out `func_documentation_tokens ` has less than 3 characters to only consider information rich docstring as query.

Default ndcg@10 mearesure has been changed to mean reciprocal rank to adopt the nature of 1-1 match